### PR TITLE
Config.cs Comments

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -18,6 +18,9 @@ namespace Byaltek
         private static int cachePollTime = 0;
         private static int bundleCacheTTL = 0;
 
+        /// <summary>
+        /// Account name of the Azure Storage account where the files will be read from, and the bundles will be published to.
+        /// </summary>
         public static string AzureAccountName
         {
             get
@@ -26,6 +29,9 @@ namespace Byaltek
                 return azureAccountName;
             }
         }
+        /// <summary>
+        /// Access key for the Azure Storage account where the files will be read from, and the bundles will be published to.
+        /// </summary>
         public static string AzureAccessKey
         {
             get
@@ -34,6 +40,14 @@ namespace Byaltek
                 return azureAccessKey;
             }
         }
+        /// <summary>
+        /// If you use a custom domain for your Azure CDN, supply that here. If you will not be using a custom domain, supply the 
+        /// default CDN name from Azure. Do not include the blob container name. If you will be using blob storage to serve the 
+        /// files rather than a CDN, supply the path for blob storage.
+        /// </summary>
+        /// <example>
+        /// http://cdn.yourdomain.com/
+        /// </example>
         public static string CdnPath
         {
             get
@@ -42,6 +56,13 @@ namespace Byaltek
                 return cdnPath;
             }
         }
+        /// <summary>
+        /// Azure does not yet allow https to be used with custom domains on the CDN, so supply the default CDN path here for use in 
+        /// https scenarios. If you will be using blob storage to serve the files rather than a CDN, supply the https path for blob storage.
+        /// </summary>
+        /// <example>
+        /// https://az217414.vo.msecnd.net/
+        /// </example>
         public static string SecureCdnPath
         {
             get
@@ -50,6 +71,10 @@ namespace Byaltek
                 return secureCdnPath;
             }
         }
+        /// <summary>
+        /// The value in seconds for how often you want the source files in the Azure storage account to be checked for changes. By default,
+        /// it is set to zero and will check on every request.
+        /// </summary>
         public static int CachePollTime
         {
             get
@@ -58,6 +83,10 @@ namespace Byaltek
                 return cachePollTime;
             }
         }
+        /// <summary>
+        /// The value that will be set in the cache control header for the bundle. This will control how often the CDN checks for a new version
+        /// and how long the file is cached on the client browser.
+        /// </summary>
         public static int BundleCacheTTL
         {
             get
@@ -69,6 +98,10 @@ namespace Byaltek
 
         #endregion
 
+        /// <summary>
+        /// If configuration values are not yet set, it checks for the appropriate keys in the web.config app settings, and if those do not
+        /// exist, it looks for them in a Config.json file in the site root.
+        /// </summary>
         public static void LoadConfig()
         {
             try
@@ -132,6 +165,9 @@ namespace Byaltek
             }
         }
 
+        /// <summary>
+        /// Reads the settings from the Config.json file in the site root
+        /// </summary>
         private static string jsonString
         {
             get
@@ -145,6 +181,12 @@ namespace Byaltek
             }
         }
 
+        /// <summary>
+        /// Gets the specified setting from the Config.json file
+        /// </summary>
+        /// <param name="toParse">String containing JSON file</param>
+        /// <param name="property">Setting name to retrieve</param>
+        /// <returns>Strind value of the setting</returns>
         private static string GetJson(string toParse, string property)
         {
             if (!string.IsNullOrEmpty(toParse))

--- a/Config.cs
+++ b/Config.cs
@@ -143,19 +143,35 @@ namespace Byaltek
                     }
                     if (WebConfigurationManager.AppSettings["CachePollTime"] != null)
                     {
-                        cachePollTime = Convert.ToInt32(WebConfigurationManager.AppSettings["CachePollTime"]);
+                        int oldCachePollTime = cachePollTime;
+                        if (!Int32.TryParse(WebConfigurationManager.AppSettings["CachePollTime"], out cachePollTime))
+                        {
+                            cachePollTime = oldCachePollTime;
+                        }
                     }
                     else
                     {
-                        cachePollTime = Convert.ToInt32(GetJson(jsonString, "CachePollTime"));
+                        int oldCachePollTime = cachePollTime;
+                        if (!Int32.TryParse(GetJson(jsonString, "CachePollTime"), out cachePollTime))
+                        {
+                            cachePollTime = oldCachePollTime;
+                        }
                     }
                     if (WebConfigurationManager.AppSettings["BundleCacheTTL"] != null)
                     {
-                        bundleCacheTTL = Convert.ToInt32(WebConfigurationManager.AppSettings["BundleCacheTTL"]);
+                        int oldBundleCacheTTL = bundleCacheTTL;
+                        if (!Int32.TryParse(WebConfigurationManager.AppSettings["BundleCacheTTL"], out bundleCacheTTL))
+                        {
+                            bundleCacheTTL = oldBundleCacheTTL;
+                        }
                     }
                     else
                     {
-                        bundleCacheTTL = Convert.ToInt32(GetJson(jsonString, "BundleCacheTTL"));
+                        int oldBundleCacheTTL = bundleCacheTTL;
+                        if (!Int32.TryParse(GetJson(jsonString, "BundleCacheTTL"), out bundleCacheTTL))
+                        {
+                            bundleCacheTTL = oldBundleCacheTTL;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This adds comments to the methods and props on Config.cs. It also changes the parsing of the integer values from the web.config and Config.json files to use TryParse rather than Convert.
